### PR TITLE
Reset error count per batch insert

### DIFF
--- a/lib/dynamo_insert.js
+++ b/lib/dynamo_insert.js
@@ -43,6 +43,7 @@ var LIST = []; // YES! its a GLOBAL!! :-O but its scoped to this module.
  */
 module.exports = function batch_insert (env, id, results, callback) {
   LIST = []; // reset the LIST for each batch of inserts
+  ERROR_COUNT = 0; // reset the error count for this batch
   SUBKEY = Date.now();
   // var batches = Math.ceil(results / 30);
   var count = 0;


### PR DESCRIPTION
Without resetting the error count on a fresh batch insert then no errors will be logged in the lambda container is re-used. Resetting the count means that we can ensure that no errors are ignored.

Fixes #57 