### PR TITLE
Update version of aws-lambda-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/numo-labs/lambda-ne-classic-package-provider#readme",
   "dependencies": {
-    "aws-lambda-helper": "^2.13.4",
+    "aws-lambda-helper": "^2.14.0",
     "dynamodb-doc": "^1.0.0",
     "env2": "^2.0.8",
     "lodash.result": "^4.4.0"


### PR DESCRIPTION
We want to use the new version (2.14.0) of the lambda helper that sends search results to SNS events.