### PR TITLE
Refactor api_request

### DIFF
--- a/lib/api_request.js
+++ b/lib/api_request.js
@@ -4,6 +4,7 @@ var http_request = require('./http_request');
 var mapper = require('./result_mapper');
 var STAGE = 'ci'; // re-assigned if necessary
 var HOTEL_INFO_CACHE = {}; // use the lambda memory to server requests *even* faster
+var EventEmitter = require('events');
 
 /**
  * make_path_from_params constructs the string that is used to request
@@ -72,86 +73,83 @@ function get_hotel_info (hid, callback) {
  * standard node params. e.g: function callback (err, response) { ... }
  */
 module.exports = function api_request (params, callback) {
-  STAGE = (params.stage === '$LATEST' || !params.stage) ? 'ci' : params.stage;
-  var log = [];
-  var body = JSON.parse(JSON.stringify(params));
-  // split the requests for packages into One API Request Per hotelId (parallel requests)
-  if (params.hotelIds && params.hotelIds.length > 0) {
-    var hids = params.hotelIds.split(',');
-    var countdown = hids.length;
-    var results = {totalHits: 0, result: []}; // collect all package results
-    hids.forEach(function (hid, index) { // parallel queries to API Gateway Cache
-      var _params = JSON.parse(JSON.stringify(params)); // clone to avoid mutation
-      _params.hotelIds = hid;
-      var options = make_options(_params);
-      var req = 'https://' + options.host + options.path;
-      http_request(options, function (err, data) {
-        // only proceed if there is a Package result for the Hotel
-        if (!err && data.result && data.result.length > 0) {
-          data.totalHits = data.totalHits;
-          log.push({'api_request': req, 'hits': data.totalHits});
-          var pkg = [data.result.sort(sort_by_price_asc)[0]]; // get cheapest package
+  var ee = new EventEmitter();
+  process.nextTick(callApi);
+  return ee;
 
-          get_hotel_info(hid, function (err, hotel_info) {
-            // format one package result at a time:
-            var records = mapper.map_ne_result_to_graphql(pkg, hotel_info);
-            body.items = records;
-            // push records to client via Websockets
-            AwsHelper.pushResultToClient(body, function (err, result) {
-              AwsHelper.log.trace({ err: err }, 'Packages Pushed to Client');
+  function callApi () {
+    STAGE = (params.stage === '$LATEST' || !params.stage) ? 'ci' : params.stage;
+    var log = [];
+    var body = JSON.parse(JSON.stringify(params));
+    // split the requests for packages into One API Request Per hotelId (parallel requests)
+    if (params.hotelIds && params.hotelIds.length > 0) {
+      var hids = params.hotelIds.split(',');
+      var countdown = hids.length;
+      var results = {totalHits: 0, result: []}; // collect all package results
+      hids.forEach(function (hid, index) { // parallel queries to API Gateway Cache
+        var _params = JSON.parse(JSON.stringify(params)); // clone to avoid mutation
+        _params.hotelIds = hid;
+        var options = make_options(_params);
+        var req = 'https://' + options.host + options.path;
+        http_request(options, function (err, data) {
+          // only proceed if there is a Package result for the Hotel
+          if (!err && data.result && data.result.length > 0) {
+            data.totalHits = data.totalHits;
+            log.push({'api_request': req, 'hits': data.totalHits});
+            var pkg = [data.result.sort(sort_by_price_asc)[0]]; // get cheapest package
+
+            get_hotel_info(hid, function (err, hotel_info) {
+              // format one package result at a time:
+              var records = mapper.map_ne_result_to_graphql(pkg, hotel_info);
+              body.items = records;
+              ee.emit('result', body);
+              results.result.push(records[0]);
+              results.totalHits += data.totalHits;
+              if (--countdown === 0) {
+                AwsHelper.log.info({ 'results': log }, 'Package Results');
+                return callback(err, results);
+              }
             });
-            results.result.push(records[0]);
-            results.totalHits += data.totalHits;
-            if (--countdown === 0) {
+          } else { // each result is sent to the client as it is received from API
+            log.push({'api_request_error': err, 'hotelId': hid, request: req});
+            if (--countdown === 0) { // so there's no need to send them here
               AwsHelper.log.info({ 'results': log }, 'Package Results');
               return callback(err, results);
             }
-          });
-        } else { // each result is sent to the client as it is received from API
-          log.push({'api_request_error': err, 'hotelId': hid, request: req});
-          if (--countdown === 0) { // so there's no need to send them here
-            AwsHelper.log.info({ 'results': log }, 'Package Results');
-            return callback(err, results);
           }
+        });
+      });
+    } else { // otherwise only one api request is required (no hotelIds list)
+      AwsHelper.log.info({'message': 'No Hotel Ids Supplied in SNS Message'});
+      var options = make_options(params);
+      http_request(options, function (err, data) {
+        if (err) {
+          AwsHelper.log.info({err: err}, 'No Hotels Package results');
+          return callback(err);
+        } else {
+          var packages = {}; // the easy way to dedupe the packages
+          data.result.sort(sort_by_price_asc).forEach(function (res) {
+            packages[res.wvHotelPartId] = res;
+          });
+          var unique_packages = Object.keys(packages).slice(0, 30).map(function (hid) { return packages[hid]; });
+          var countdown = unique_packages.length;
+          var hotels = [];
+          Object.keys(packages).slice(0, 30).forEach(function (hid) {
+            get_hotel_info(hid, function (err, hotel_info) {
+              AwsHelper.log.info({ err: err }, 'Error retrieving hotel info');
+              // assert(!err);
+              hotels.push(hotel_info[0]);
+              if (--countdown === 0) {
+                AwsHelper.log.info({ err: err, 'results': log }, 'Package Results');
+                body.items = mapper.map_ne_result_to_graphql(unique_packages, hotels);
+                ee.emit('result', body);
+                return callback(err, {result: body.items, totalHits: data.result.length});
+              }
+            });
+          });
         }
       });
-    });
-  } else { // otherwise only one api request is required (no hotelIds list)
-    AwsHelper.log.info({'message': 'No Hotel Ids Supplied in SNS Message'});
-    var options = make_options(params);
-    http_request(options, function (err, data) {
-      if (err) {
-        AwsHelper.log.info({err: err}, 'No Hotels Package results');
-        // should we attempt to inform the client that there was an error?
-        body.items = [];
-        AwsHelper.pushToSocketServer(body, function (e, res) {
-          return callback(err);
-        });
-      } else {
-        var packages = {}; // the easy way to dedupe the packages
-        data.result.sort(sort_by_price_asc).forEach(function (res) {
-          packages[res.wvHotelPartId] = res;
-        });
-        var unique_packages = Object.keys(packages).slice(0, 30).map(function (hid) { return packages[hid]; });
-        var countdown = unique_packages.length;
-        var hotels = [];
-        Object.keys(packages).slice(0, 30).forEach(function (hid) {
-          get_hotel_info(hid, function (err, hotel_info) {
-            AwsHelper.log.info({ err: err }, 'Error retrieving hotel info');
-            // assert(!err);
-            hotels.push(hotel_info[0]);
-            if (--countdown === 0) {
-              AwsHelper.log.info({ err: err, 'results': log }, 'Package Results');
-              body.items = mapper.map_ne_result_to_graphql(unique_packages, hotels);
-              AwsHelper.pushResultToClient(body, function (err, result) {
-                AwsHelper.log.info({ err: err }, 'Sending Packages to Client via WebSocket Server');
-              });
-              return callback(err, {result: body.items, totalHits: data.result.length});
-            }
-          });
-        });
-      }
-    });
+    }
   }
 };
 


### PR DESCRIPTION
`api_request` now returns an event emitter. Instead of sending search
results back to the client from inside `api_request`, we can now do
it from the handler, and have the ability to buffer / filter responses
before they are sent to the client.