### PR TITLE
Emit SNS event on search complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ exports.handler = function (event, context, callback) {
     body.searchComplete = true;
     AwsHelper.pushResultToClient(body, () => {
       AwsHelper.log.info({ err: err, packages: response.result.length },
-        `Package search complete: ${response.result.length} packages found`);
+        'Package search complete');
     });
     if (err || !response.result || response.result.length === 0) {
       return callback(new Error('No packages found'));


### PR DESCRIPTION
Always sends an event when all package results have been returned, irrespective of the the number of results. This allows subscribed clients to be aware that they are not expecting to receive further results.

Additionally adds a boolean property of `searchComplete` to emitted messages to indicate the state.

Closes #91 
Closes #92