### PR TITLE
Give us easier to understand logs

### DIFF
--- a/lib/api_request.js
+++ b/lib/api_request.js
@@ -107,6 +107,7 @@ module.exports = function api_request (params, callback) {
                 /* istanbul ignore if */
                 if (err) {
                   log.push({get_hotel_info_error: err, hotelId: hid, request: req, date: new Date()});
+                  AwsHelper.log.warn({ err: err, hotelId: hid, request: req }, 'Unable to get hotel info');
                   return done(null, null);
                 }
 
@@ -129,7 +130,8 @@ module.exports = function api_request (params, callback) {
         },
         function (_err, results) {
           assert(!_err); // err is ALWAYS null (never callback with actual error)
-          AwsHelper.log.info({ 'results': log }, 'Package Results');
+          AwsHelper.log.trace({ 'results': log }, 'Package Results');
+          AwsHelper.log.info({ 'results': totalHits }, 'Package Results');
           results = results.filter(function (a) { return a !== null; });
           return callback(_err, { result: results, totalHits: totalHits });
         });
@@ -154,7 +156,8 @@ module.exports = function api_request (params, callback) {
               AwsHelper.log.info({ err: err, info: hotel_info }, 'Error retrieving hotel info');
               hotels.push(hotel_info[0]);
               if (--countdown === 0) {
-                AwsHelper.log.info({ err: err, 'results': log }, 'Package Results');
+                AwsHelper.log.trace({ err: err, 'results': log }, 'Package Results');
+                AwsHelper.log.info({ 'results': data.result.length }, 'Package Results');
                 body.items = mapper.map_ne_result_to_graphql(unique_packages, hotels);
                 ee.emit('result', body);
                 return callback(err, {result: body.items, totalHits: data.result.length});


### PR DESCRIPTION
If verbosity is needed then we can set the request-log-level to `trace`