### PR TITLE
Error handling - timing out is not an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,13 @@ exports.handler = function (event, context, callback) {
 
     setInterval(function () {
       if (context.getRemainingTimeInMillis() < 1000) {
-        AwsHelper.log.info({ count: hids - resultsReturned },
-                           'Hotels still remaining just before we time out');
+        AwsHelper.log.error({ count: hids - resultsReturned },
+                            'Hotels still remaining just before we time out');
+        if (resultsReturned > 0) {
+          return callback(null, resultsReturned);
+        } else {
+          return callback(new Error('No results returned before lambda\'s timeout'), 0);
+        }
       }
     }, 500).unref();
   }


### PR DESCRIPTION
The lambda timing out before all hotel ids have been processed
isn't really an error as long as some results have been pushed
back to the client. A lot of invocations *will* timeout because
the number of hotel ids to look at is large and the external API
is slow - which will then pollute the monitoring dashboard with
errors that aren't actionable.