### PR TITLE
Package tiles extra data

### DIFF
--- a/lib/result_mapper.js
+++ b/lib/result_mapper.js
@@ -178,7 +178,10 @@ function minimiseBandwidth (item) {
       },
       price: item.packageOffer.price, // all fields
       provider: item.packageOffer.provider, // all fields
-      nights: item.packageOffer.nights
+      nights: item.packageOffer.nights,
+      destinationCode: item.packageOffer.destinationCode,
+      destinationName: item.packageOffer.destinationName,
+      departureCode: item.packageOffer.departureCode
     }
   };
 }


### PR DESCRIPTION
In order to have at front end the required data for analytics it's needed to add `destinationCode`, `destinationName` and `departureCode`.


> **Missing dimensions in hotel product objects**

>We want to send the &quot;custom&quot; dimensions (11,12,13) in all ecommerce actions (impressions, clicks, detailed viewed, add-to- carts). This is currently only done for &quot;add-to- carts&quot; i.e., when the user makes a click-through from an expanded hotel tile to the Spies site. See the measurement plan for details.
>[Source](https://drive.google.com/drive/u/1/folders/0B1aHHUZuc5YOT1ZPR0xEVjlrbm8)