### PR TITLE
Use `pushToSNSTopic` to send complete event back to client

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ exports.handler = function (event, context, callback) {
     delete body.hotelIds; // don't need hotelIds again https://git.io/voIAS
     body.items = []; // send an empty array to the client so it knows wazzup!
     body.searchComplete = true;
-    AwsHelper.pushResultToClient(body, () => {
+    AwsHelper.pushToSNSTopic(body, () => {
       AwsHelper.log.info({ err: err, packages: response.result.length },
         'Package search complete');
     });


### PR DESCRIPTION
Since https://github.com/numo-labs/aws-lambda-helper/commit/91fefdd5e88bdacb492e0b7fc4ad93da533b82ca#diff-6d186b954a58d5bb740f73d84fe39073R320 we cannot use `pushResultToClient` to send events that are not search results to the client without throwing an error, and so we need to use `pushToSNSTopic` instead.

I'm not sure how many of the bugs this will be a direct cause for, but I think that it is likely causing a number of issues when search results are not returned as it means that the client will never receive a `complete` event and be able to determine that no results are still to be returned, and so will wait until it times out.